### PR TITLE
chore: drop linkerd injection

### DIFF
--- a/internal/task/run_job.go
+++ b/internal/task/run_job.go
@@ -66,9 +66,6 @@ func (tr *taskRunner) buildJobObject() (*k8sbatchv1.Job, error) {
 					Labels: map[string]string{
 						labelKeyTaskName: taskName,
 					},
-					Annotations: map[string]string{
-						"linkerd.io/inject": "enabled",
-					},
 				},
 				Spec: k8scorev1.PodSpec{
 					Containers: []k8scorev1.Container{


### PR DESCRIPTION
The linkerd injection was for internal usage only. We are going to add partial patch support to the job spec, we can safely remove this feature for now.